### PR TITLE
Indicate types declaration file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "module": "dist/imagekit.esm.js",
     "browser": "dist/imagekit.min.js",
     "unpkg": "dist/imagekit.min.js",
+    "types": "dist/src/index.d.ts",
     "files": [
         "dist",
         "src"


### PR DESCRIPTION
As per the [TS docs ][0] the main declaration file should be indicated in
package.json. Without it TS is unable to provide types for the package.

[0]: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html