### PR TITLE
Allow upload tags as array

### DIFF
--- a/src/interfaces/UploadOptions.ts
+++ b/src/interfaces/UploadOptions.ts
@@ -36,7 +36,7 @@ export interface UploadOptions {
    * - % is not allowed.
    * - If this field is not specified and the file is overwritten then the tags will be removed.
    */
-  tags?: string;
+  tags?: string | string[];
   /**
    * The folder path (e.g. /images/folder/) in which the image has to be uploaded. If the folder(s) didn't exist before, a new folder(s) is created.
    * The folder name can contain:


### PR DESCRIPTION
Tags can be provided as an array rather than a comma-separated string
as FormData will coerce it.

```js
const form = new FormData()
form.append('tags', ['a', 'b'])
Object.fromEntries(form)
// Object { tags: "a,b" }
``